### PR TITLE
Correction of TWIDDLE_CLASSPATH when runnig against JBoss server

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ which (with WildFly 8.0.0.Beta1) would give an output of something like
 	UnloadedClassCount=0
 	ObjectName=java.lang:type=ClassLoading
 
+When running against JBoss/EAP server, please, manually uncomment JBoss section in twiddle.sh
+
 ## Compatibility
 
 This version of twiddle-standalone has successfully (and unaltered)  been tested on

--- a/bin/twiddle.sh
+++ b/bin/twiddle.sh
@@ -20,6 +20,7 @@
 # JBoss AS7
 #JBOSS_MODULEPATH=$JBOSS_HOME/modules
 #MODULES="org/jboss/remoting3/remoting-jmx org/jboss/remoting3 org/jboss/logging org/jboss/xnio org/jboss/xnio/nio org/jboss/sasl org/jboss/marshalling org/jboss/marshalling/river org/jboss/as/cli org/jboss/staxmapper org/jboss/as/protocol org/jboss/dmr org/jboss/as/controller-client org/jboss/threads org/jboss/as/controller"
+#TWIDDLE_CLASSPATH="$TWIDDLE_CLASSPATH:$JBOSS_HOME/bin/client/jboss-client.jar"
 
 # WildFly
 JBOSS_MODULEPATH=$JBOSS_HOME/modules/system/layers/base/


### PR DESCRIPTION
Hi,

I was trying to run your twiddle tool with the JBoss EAP 6.2 server and I've hit a problem that jboss-client.jar was not on path and getting exception that jmx-remote protocol unknown. I'm sending this pull request and suggesting a fix on it.

Cheers
Ondra 
